### PR TITLE
Shape Check + Housekeeping

### DIFF
--- a/fl_server_core/utils/torch_serialization.py
+++ b/fl_server_core/utils/torch_serialization.py
@@ -41,7 +41,8 @@ def to_torch(obj: Any, supported_types: Type[T] | Tuple[Type[T], ...]):
                 message="'torch.load' received a zip file that looks like a TorchScript archive",
                 category=UserWarning
             )
-            t_obj = torch.load(obj)
+            # default for "weights_only" will chnage in upcomning torch versions!
+            t_obj = torch.load(obj, weights_only=False)
     except Exception as e:
         getLogger("fl.server").error(f"Error loading torch object: {e}")
         raise TorchDeserializationException("Error loading torch object") from e


### PR DESCRIPTION
- Implemented shape check on inference (+ unit test)
- Disabled inference for LocalModels (made the code more complicated and wasn't needed imo) (+ unit test adapted)
- Surpressed a warning regarding a default parameter change in torch.load